### PR TITLE
explicitly show invalid mandate

### DIFF
--- a/src/runtime/components/MollieCreditCardMandates.vue
+++ b/src/runtime/components/MollieCreditCardMandates.vue
@@ -49,8 +49,10 @@ const changeMandate = async () => {
                         class="mollie-credit-card-mandates__radio-styled-checked"
                     />
                 </span>
-                {{ mandate.details.cardLabel }} - {{ mandate.details.cardHolder }} - ****
-                {{ mandate.details.cardNumber }}
+                {{ mandate.details.cardLabel && mandate.details.cardHolder && mandate.details.cardNumber
+                    ? `${mandate.details.cardLabel} - ${mandate.details.cardHolder} - **** ${mandate.details.cardNumber}`
+                    : 'Invalid'
+                }}
             </label>
         </div>
 


### PR DESCRIPTION
Show invalid mandates with no details with 'Invalid' Text instead of just showing --****
![Screenshot at Dec 09 11-26-32](https://github.com/user-attachments/assets/cb4b36ea-533f-4c4f-962f-255fea567326)